### PR TITLE
feat: migrate build system to Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Go build artifacts
+fare-finder
+*.exe
+
+# Gradle
+.gradle/
+build/

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,27 @@
+group = 'com.github.lakamsani'
+version = '1.0.0'
+
+tasks.register('build', Exec) {
+    description = 'Build the Go project'
+    group = 'build'
+    commandLine 'go', 'build', './...'
+}
+
+tasks.register('test', Exec) {
+    description = 'Run Go tests'
+    group = 'verification'
+    commandLine 'go', 'test', '-v', './...'
+}
+
+tasks.register('run', Exec) {
+    description = 'Run the fare-finder main program'
+    group = 'application'
+    commandLine 'go', 'run', '.'
+    // Pass args via: gradle run --args="city1 state1 city2 state2"
+    doFirst {
+        def appArgs = findProperty('args')
+        if (appArgs) {
+            commandLine = ['go', 'run', '.'] + appArgs.split(' ').toList()
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'fare-finder'


### PR DESCRIPTION
## Summary

- Add `build.gradle` with `build`, `test`, and `run` tasks using Gradle's `Exec` task type — no JVM plugin needed, pure Go toolchain delegation
- Add `settings.gradle` setting `rootProject.name = 'fare-finder'`
- Add `.gitignore` to exclude Gradle cache (`.gradle/`) and build output (`build/`)

## Task mapping

| Gradle task | Go command |
|-------------|------------|
| `gradle build` | `go build ./...` |
| `gradle test` | `go test -v ./...` |
| `gradle run` | `go run .` |

Pass arguments to `run` via `-Pargs`: e.g. `gradle run -Pargs="\"San Francisco\" CA \"New York\" NY"`

Go module files (`go.mod`) are kept intact — Gradle is an additive wrapper, not a replacement.

## Test plan

- [ ] Ensure Go is in `PATH`
- [ ] `gradle build` compiles successfully
- [ ] `gradle test` runs all Go tests and they pass
- [ ] `gradle run` prints usage (requires `-Pargs` with 4 args)

🤖 Generated with [Claude Code](https://claude.com/claude-code)