### PR TITLE
feat: add Python port of fare-finder

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+.Python
+*.egg-info/
+dist/
+build/
+.pytest_cache/
+.venv/
+venv/

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,54 @@
+# fare-finder (Python)
+
+A CLI tool to find the cheapest flights between US cities using the
+[SerpAPI Google Flights engine](https://serpapi.com/google-flights-api).
+
+## Requirements
+
+- Python 3.11+
+- A [SerpAPI](https://serpapi.com) API key
+
+## Setup
+
+```bash
+cd python
+pip install -e .
+```
+
+## Usage
+
+```bash
+export SERPAPI_KEY=your_key_here
+fare-finder "San Francisco" CA "New York" NY
+```
+
+Or run directly:
+
+```bash
+python -m fare_finder.main "San Francisco" CA "New York" NY
+```
+
+Example output:
+
+```
+Searching for flights SFO -> JFK on 2024-01-16...
+
+Cheapest flight: SFO -> JFK
+JetBlue B6 123
+$189
+Departs 2024-01-16 07:00 | Arrives 2024-01-16 15:30
+Duration: 5h 30m
+```
+
+## Running Tests
+
+```bash
+cd python
+pip install pytest
+pytest -v
+```
+
+## Supported Cities
+
+Covers 42 major US cities including New York (JFK), Los Angeles (LAX),
+Chicago (ORD), San Francisco (SFO), and more.

--- a/python/fare_finder/__init__.py
+++ b/python/fare_finder/__init__.py
@@ -1,0 +1,1 @@
+# fare_finder package

--- a/python/fare_finder/airport.py
+++ b/python/fare_finder/airport.py
@@ -1,0 +1,66 @@
+"""Provides IATA airport code lookup by city and state."""
+
+_AIRPORTS: dict[str, str] = {
+    "new york,ny":       "JFK",
+    "los angeles,ca":    "LAX",
+    "chicago,il":        "ORD",
+    "houston,tx":        "IAH",
+    "phoenix,az":        "PHX",
+    "philadelphia,pa":   "PHL",
+    "san antonio,tx":    "SAT",
+    "san diego,ca":      "SAN",
+    "dallas,tx":         "DFW",
+    "san jose,ca":       "SJC",
+    "austin,tx":         "AUS",
+    "jacksonville,fl":   "JAX",
+    "san francisco,ca":  "SFO",
+    "columbus,oh":       "CMH",
+    "charlotte,nc":      "CLT",
+    "indianapolis,in":   "IND",
+    "seattle,wa":        "SEA",
+    "denver,co":         "DEN",
+    "nashville,tn":      "BNA",
+    "oklahoma city,ok":  "OKC",
+    "el paso,tx":        "ELP",
+    "washington,dc":     "DCA",
+    "las vegas,nv":      "LAS",
+    "louisville,ky":     "SDF",
+    "baltimore,md":      "BWI",
+    "milwaukee,wi":      "MKE",
+    "albuquerque,nm":    "ABQ",
+    "tucson,az":         "TUS",
+    "fresno,ca":         "FAT",
+    "sacramento,ca":     "SMF",
+    "kansas city,mo":    "MCI",
+    "atlanta,ga":        "ATL",
+    "miami,fl":          "MIA",
+    "minneapolis,mn":    "MSP",
+    "portland,or":       "PDX",
+    "detroit,mi":        "DTW",
+    "boston,ma":         "BOS",
+    "memphis,tn":        "MEM",
+    "new orleans,la":    "MSY",
+    "cleveland,oh":      "CLE",
+    "tampa,fl":          "TPA",
+    "orlando,fl":        "MCO",
+}
+
+
+def lookup_airport(city: str, state: str) -> str:
+    """Return the IATA code for a given city and state.
+
+    Args:
+        city:  The city name (case-insensitive).
+        state: The two-letter state code (case-insensitive).
+
+    Returns:
+        The IATA airport code (e.g. ``"SFO"``).
+
+    Raises:
+        ValueError: If no airport is found for the given city/state pair.
+    """
+    key = f"{city.strip().lower()},{state.strip().lower()}"
+    code = _AIRPORTS.get(key)
+    if code is None:
+        raise ValueError(f"no airport found for {city}, {state}")
+    return code

--- a/python/fare_finder/flight.py
+++ b/python/fare_finder/flight.py
@@ -1,0 +1,28 @@
+"""Represents a single flight option."""
+
+
+class Flight:
+    """A single flight option with airline, flight number, price, times, and duration."""
+
+    def __init__(
+        self,
+        airline: str,
+        flight_number: str,
+        price: int,
+        departure_time: str,
+        arrival_time: str,
+        duration: str,
+    ) -> None:
+        self.airline = airline
+        self.flight_number = flight_number
+        self.price = price
+        self.departure_time = departure_time
+        self.arrival_time = arrival_time
+        self.duration = duration
+
+    def __repr__(self) -> str:
+        return (
+            f"Flight(airline={self.airline!r}, flight_number={self.flight_number!r}, "
+            f"price={self.price}, departure_time={self.departure_time!r}, "
+            f"arrival_time={self.arrival_time!r}, duration={self.duration!r})"
+        )

--- a/python/fare_finder/main.py
+++ b/python/fare_finder/main.py
@@ -1,0 +1,73 @@
+"""CLI entry point for fare-finder (Python port)."""
+
+import sys
+from datetime import date, timedelta
+
+from .airport import lookup_airport
+from .searcher import search_flights
+
+
+def _title_case(s: str) -> str:
+    """Capitalise the first letter of each word."""
+    return " ".join(word.capitalize() for word in s.split())
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Parse CLI arguments and print the cheapest flight."""
+    args = sys.argv[1:] if argv is None else argv
+
+    if len(args) != 4:
+        print(
+            "Usage: fare-finder <city1> <state1> <city2> <state2>",
+            file=sys.stderr,
+        )
+        print(
+            'Example: fare-finder "San Francisco" CA "New York" NY',
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    city1 = _title_case(args[0].strip())
+    state1 = args[1].strip().upper()
+    city2 = _title_case(args[2].strip())
+    state2 = args[3].strip().upper()
+
+    try:
+        origin = lookup_airport(city1, state1)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        dest = lookup_airport(city2, state2)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    tomorrow = (date.today() + timedelta(days=1)).strftime("%Y-%m-%d")
+
+    print(f"Searching for flights {origin} -> {dest} on {tomorrow}...\n")
+
+    try:
+        flights = search_flights(origin, dest, tomorrow)
+    except Exception as exc:  # noqa: BLE001
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    if not flights:
+        print(
+            "No flights found for this route and date. "
+            "Try a different date or city pair."
+        )
+        sys.exit(0)
+
+    cheapest = flights[0]
+    print(f"Cheapest flight: {origin} -> {dest}")
+    print(f"{cheapest.airline} {cheapest.flight_number}")
+    print(f"${cheapest.price}")
+    print(f"Departs {cheapest.departure_time} | Arrives {cheapest.arrival_time}")
+    print(f"Duration: {cheapest.duration}")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/fare_finder/searcher.py
+++ b/python/fare_finder/searcher.py
@@ -1,0 +1,142 @@
+"""Handles flight search via SerpAPI and JSON parsing."""
+
+import json
+import os
+import urllib.request
+import urllib.parse
+from typing import Optional
+
+from .flight import Flight
+
+# SerpAPI endpoint — can be overridden in tests.
+_BASE_URL = "https://serpapi.com/search"
+
+# API key override for testing.
+# None  = read from SERPAPI_KEY env var
+# ""    = simulate missing key (triggers error)
+# other = use directly
+_api_key_override: Optional[str] = None
+
+
+def _set_base_url(url: str) -> None:
+    """Override the SerpAPI base URL (for tests)."""
+    global _BASE_URL
+    _BASE_URL = url
+
+
+def _set_api_key_override(key: Optional[str]) -> None:
+    """Override the API key (for tests). Pass None to reset."""
+    global _api_key_override
+    _api_key_override = key
+
+
+def search_flights(origin: str, dest: str, date: str) -> list[Flight]:
+    """Fetch flights from SerpAPI for the given origin, destination, and date.
+
+    Args:
+        origin: 3-letter IATA origin code.
+        dest:   3-letter IATA destination code.
+        date:   Departure date in ``YYYY-MM-DD`` format.
+
+    Returns:
+        List of :class:`Flight` objects sorted by price ascending.
+
+    Raises:
+        ValueError: If the SerpAPI key is missing.
+        RuntimeError: If the HTTP request fails or returns a non-200 status.
+    """
+    if _api_key_override is not None:
+        api_key = _api_key_override
+    else:
+        api_key = os.environ.get("SERPAPI_KEY", "")
+
+    if not api_key:
+        raise ValueError(
+            "SERPAPI_KEY environment variable is not set. Get a key at https://serpapi.com"
+        )
+
+    params = urllib.parse.urlencode(
+        {
+            "engine": "google_flights",
+            "departure_id": origin,
+            "arrival_id": dest,
+            "outbound_date": date,
+            "currency": "USD",
+            "hl": "en",
+            "api_key": api_key,
+            "type": "2",
+        }
+    )
+    url = f"{_BASE_URL}?{params}"
+
+    req = urllib.request.Request(url)
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status != 200:
+                raise RuntimeError(f"API returned status {resp.status}")
+            body = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(f"API returned status {exc.code}") from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(f"HTTP request failed: {exc.reason}") from exc
+
+    return parse_flights(body)
+
+
+def parse_flights(json_text: str) -> list[Flight]:
+    """Parse a SerpAPI JSON response and return flights sorted by price ascending.
+
+    Args:
+        json_text: Raw JSON string from SerpAPI.
+
+    Returns:
+        List of :class:`Flight` objects sorted by price ascending.
+
+    Raises:
+        ValueError: If JSON parsing fails.
+    """
+    try:
+        data = json.loads(json_text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"failed to parse JSON: {exc}") from exc
+
+    flights: list[Flight] = []
+
+    for group_key in ("best_flights", "other_flights"):
+        groups = data.get(group_key, [])
+        if not isinstance(groups, list):
+            continue
+        for group in groups:
+            legs = group.get("flights", [])
+            if not legs:
+                continue
+            price = int(group.get("price", 0))
+
+            first_leg = legs[0]
+            last_leg = legs[-1]
+
+            airline = first_leg.get("airline", "")
+            flight_number = first_leg.get("flight_number", "")
+            departure_time = first_leg.get("departure_airport", {}).get("time", "")
+            arrival_time = last_leg.get("arrival_airport", {}).get("time", "")
+
+            total_duration = sum(leg.get("duration", 0) for leg in legs)
+
+            flights.append(
+                Flight(
+                    airline=airline,
+                    flight_number=flight_number,
+                    price=price,
+                    departure_time=departure_time,
+                    arrival_time=arrival_time,
+                    duration=_format_duration(total_duration),
+                )
+            )
+
+    flights.sort(key=lambda f: f.price)
+    return flights
+
+
+def _format_duration(minutes: int) -> str:
+    """Convert total minutes into a human-readable ``Xh Ym`` string."""
+    return f"{minutes // 60}h {minutes % 60}m"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,0 +1,20 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "fare-finder"
+version = "1.0.0"
+description = "CLI tool to find the cheapest flights between US cities via SerpAPI"
+requires-python = ">=3.11"
+dependencies = []
+
+[project.scripts]
+fare-finder = "fare_finder.main:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["fare_finder*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/python/tests/__init__.py
+++ b/python/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/python/tests/test_airport.py
+++ b/python/tests/test_airport.py
@@ -1,0 +1,30 @@
+"""Tests for the airport lookup module."""
+
+import pytest
+
+from fare_finder.airport import lookup_airport
+
+
+@pytest.mark.parametrize(
+    "city, state, expected",
+    [
+        ("San Francisco", "CA", "SFO"),
+        ("New York",      "NY", "JFK"),
+        ("Chicago",       "IL", "ORD"),
+        ("Atlanta",       "GA", "ATL"),
+        ("Denver",        "CO", "DEN"),
+        ("Seattle",       "WA", "SEA"),
+        ("Miami",         "FL", "MIA"),
+        ("Las Vegas",     "NV", "LAS"),
+        ("Boston",        "MA", "BOS"),
+        ("Dallas",        "TX", "DFW"),
+    ],
+)
+def test_known_airports(city: str, state: str, expected: str) -> None:
+    assert lookup_airport(city, state) == expected
+
+
+def test_unknown_city_raises_value_error() -> None:
+    with pytest.raises(ValueError) as exc_info:
+        lookup_airport("Nonexistent City", "XX")
+    assert exc_info.value.args[0]  # message should be non-empty

--- a/python/tests/test_searcher.py
+++ b/python/tests/test_searcher.py
@@ -1,0 +1,84 @@
+"""Tests for the flight searcher module."""
+
+import pytest
+
+import fare_finder.searcher as searcher_module
+from fare_finder.searcher import parse_flights, search_flights
+
+MOCK_JSON = """{
+    "best_flights": [
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 08:05"},
+                    "arrival_airport":   {"time": "2024-01-15 16:23"},
+                    "duration": 318,
+                    "airline": "United Airlines",
+                    "flight_number": "UA 101"
+                }
+            ],
+            "price": 189
+        }
+    ],
+    "other_flights": [
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 10:30"},
+                    "arrival_airport":   {"time": "2024-01-15 18:45"},
+                    "duration": 315,
+                    "airline": "Delta Air Lines",
+                    "flight_number": "DL 405"
+                }
+            ],
+            "price": 245
+        },
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 06:00"},
+                    "arrival_airport":   {"time": "2024-01-15 14:10"},
+                    "duration": 310,
+                    "airline": "JetBlue",
+                    "flight_number": "B6 816"
+                }
+            ],
+            "price": 159
+        }
+    ]
+}"""
+
+
+@pytest.fixture(autouse=True)
+def reset_api_key_override():
+    """Restore the API key override after each test."""
+    original = searcher_module._api_key_override
+    yield
+    searcher_module._set_api_key_override(original)
+
+
+def test_parse_flights() -> None:
+    flights = parse_flights(MOCK_JSON)
+
+    assert len(flights) == 3, f"expected 3 flights, got {len(flights)}"
+
+    # Sorted by price ascending: 159, 189, 245
+    assert flights[0].price == 159
+    assert flights[1].price == 189
+    assert flights[2].price == 245
+
+    # Cheapest is JetBlue B6 816
+    assert flights[0].airline == "JetBlue"
+    assert flights[0].flight_number == "B6 816"
+    assert flights[0].duration == "5h 10m"
+
+
+def test_missing_serpapi_key_raises_error() -> None:
+    searcher_module._set_api_key_override("")  # simulate missing key
+
+    with pytest.raises(ValueError) as exc_info:
+        search_flights("SFO", "JFK", "2024-01-15")
+
+    msg = str(exc_info.value)
+    assert msg, "error message should not be empty"
+    assert "SERPAPI_KEY" in msg, f"expected 'SERPAPI_KEY' in message, got: {msg!r}"


### PR DESCRIPTION
## Summary

Adds a complete Python port of fare-finder under the `python/` directory, as requested in #10.

## Changes

- `python/fare_finder/airport.py` — IATA code lookup for 42 US cities
- `python/fare_finder/flight.py` — `Flight` data class
- `python/fare_finder/searcher.py` — SerpAPI search + JSON parsing
- `python/fare_finder/main.py` — CLI entry point (same UX as the Java version)
- `python/tests/test_airport.py` — Airport lookup tests (mirrors Java `AirportTest`)
- `python/tests/test_searcher.py` — Searcher tests (mirrors Java `SearcherTest`)
- `python/pyproject.toml` — PEP-517 build config; installs `fare-finder` CLI entry point
- `python/.gitignore` — Ignores `__pycache__`, `.pytest_cache`, etc.
- `python/README.md` — Setup and usage instructions

## Testing

All 13 pytest tests pass:

```
13 passed in 0.01s
```

Tests cover:
- Known airport lookups (10 parametrised cases)
- Unknown city raises `ValueError`
- JSON parsing + price-sort of `best_flights` + `other_flights`
- Missing `SERPAPI_KEY` raises `ValueError` with descriptive message

Fixes lakamsani/fare-finder#10