### PR TITLE
feat: port fare-finder to Go

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -1,0 +1,53 @@
+# fare-finder (Go)
+
+A CLI tool to find the cheapest flights between US cities using the
+[SerpAPI Google Flights engine](https://serpapi.com/google-flights-api).
+
+## Requirements
+
+- Go 1.21+
+- A [SerpAPI](https://serpapi.com) API key
+
+## Setup
+
+```bash
+cd go
+go build -o fare-finder .
+```
+
+## Usage
+
+```bash
+export SERPAPI_KEY=your_key_here
+./fare-finder "San Francisco" CA "New York" NY
+```
+
+Or run directly:
+
+```bash
+go run . "San Francisco" CA "New York" NY
+```
+
+Example output:
+
+```
+Searching for flights SFO -> JFK on 2024-01-16...
+
+Cheapest flight: SFO -> JFK
+JetBlue B6 123
+$189
+Departs 2024-01-16 07:00 | Arrives 2024-01-16 15:30
+Duration: 5h 30m
+```
+
+## Running Tests
+
+```bash
+cd go
+go test ./...
+```
+
+## Supported Cities
+
+Covers 42 major US cities including New York (JFK), Los Angeles (LAX),
+Chicago (ORD), San Francisco (SFO), and more.

--- a/go/airport.go
+++ b/go/airport.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+)
+
+var airports = map[string]string{
+	"new york,ny":      "JFK",
+	"los angeles,ca":   "LAX",
+	"chicago,il":       "ORD",
+	"houston,tx":       "IAH",
+	"phoenix,az":       "PHX",
+	"philadelphia,pa":  "PHL",
+	"san antonio,tx":   "SAT",
+	"san diego,ca":     "SAN",
+	"dallas,tx":        "DFW",
+	"san jose,ca":      "SJC",
+	"austin,tx":        "AUS",
+	"jacksonville,fl":  "JAX",
+	"san francisco,ca": "SFO",
+	"columbus,oh":      "CMH",
+	"charlotte,nc":     "CLT",
+	"indianapolis,in":  "IND",
+	"seattle,wa":       "SEA",
+	"denver,co":        "DEN",
+	"nashville,tn":     "BNA",
+	"oklahoma city,ok": "OKC",
+	"el paso,tx":       "ELP",
+	"washington,dc":    "DCA",
+	"las vegas,nv":     "LAS",
+	"louisville,ky":    "SDF",
+	"baltimore,md":     "BWI",
+	"milwaukee,wi":     "MKE",
+	"albuquerque,nm":   "ABQ",
+	"tucson,az":        "TUS",
+	"fresno,ca":        "FAT",
+	"sacramento,ca":    "SMF",
+	"kansas city,mo":   "MCI",
+	"atlanta,ga":       "ATL",
+	"miami,fl":         "MIA",
+	"minneapolis,mn":   "MSP",
+	"portland,or":      "PDX",
+	"detroit,mi":       "DTW",
+	"boston,ma":        "BOS",
+	"memphis,tn":       "MEM",
+	"new orleans,la":   "MSY",
+	"cleveland,oh":     "CLE",
+	"tampa,fl":         "TPA",
+	"orlando,fl":       "MCO",
+}
+
+// LookupAirport returns the IATA code for the given city and state.
+// Returns an error if no airport is found.
+func LookupAirport(city, state string) (string, error) {
+	key := strings.ToLower(strings.TrimSpace(city)) + "," + strings.ToLower(strings.TrimSpace(state))
+	code, ok := airports[key]
+	if !ok {
+		return "", fmt.Errorf("no airport found for %s, %s", city, state)
+	}
+	return code, nil
+}

--- a/go/airport_test.go
+++ b/go/airport_test.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestLookupAirport_KnownCities(t *testing.T) {
+	cases := []struct {
+		city, state, expected string
+	}{
+		{"San Francisco", "CA", "SFO"},
+		{"New York", "NY", "JFK"},
+		{"Chicago", "IL", "ORD"},
+		{"Atlanta", "GA", "ATL"},
+		{"Denver", "CO", "DEN"},
+		{"Seattle", "WA", "SEA"},
+		{"Miami", "FL", "MIA"},
+		{"Las Vegas", "NV", "LAS"},
+		{"Boston", "MA", "BOS"},
+		{"Dallas", "TX", "DFW"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.city+","+tc.state, func(t *testing.T) {
+			got, err := LookupAirport(tc.city, tc.state)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.expected {
+				t.Errorf("LookupAirport(%q, %q) = %q, want %q", tc.city, tc.state, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestLookupAirport_UnknownCity(t *testing.T) {
+	_, err := LookupAirport("Nonexistent City", "XX")
+	if err == nil {
+		t.Fatal("expected error for unknown city, got nil")
+	}
+	if err.Error() == "" {
+		t.Error("error message should not be empty")
+	}
+}

--- a/go/flight.go
+++ b/go/flight.go
@@ -1,0 +1,11 @@
+package main
+
+// Flight represents a single flight option.
+type Flight struct {
+	Airline       string
+	FlightNumber  string
+	Price         int
+	DepartureTime string
+	ArrivalTime   string
+	Duration      string
+}

--- a/go/go.mod
+++ b/go/go.mod
@@ -1,0 +1,3 @@
+module github.com/lakamsani/fare-finder/go
+
+go 1.21

--- a/go/main.go
+++ b/go/main.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+func titleCase(s string) string {
+	words := strings.Fields(s)
+	for i, w := range words {
+		if len(w) > 0 {
+			words[i] = strings.ToUpper(w[:1]) + strings.ToLower(w[1:])
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func main() {
+	args := os.Args[1:]
+
+	if len(args) != 4 {
+		fmt.Fprintln(os.Stderr, "Usage: fare-finder <city1> <state1> <city2> <state2>")
+		fmt.Fprintln(os.Stderr, `Example: fare-finder "San Francisco" CA "New York" NY`)
+		os.Exit(1)
+	}
+
+	city1 := titleCase(strings.TrimSpace(args[0]))
+	state1 := strings.ToUpper(strings.TrimSpace(args[1]))
+	city2 := titleCase(strings.TrimSpace(args[2]))
+	state2 := strings.ToUpper(strings.TrimSpace(args[3]))
+
+	origin, err := LookupAirport(city1, state1)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+
+	dest, err := LookupAirport(city2, state2)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+
+	tomorrow := time.Now().AddDate(0, 0, 1).Format("2006-01-02")
+
+	fmt.Printf("Searching for flights %s -> %s on %s...\n\n", origin, dest, tomorrow)
+
+	flights, err := SearchFlights(origin, dest, tomorrow)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s\n", err)
+		os.Exit(1)
+	}
+
+	if len(flights) == 0 {
+		fmt.Println("No flights found for this route and date. Try a different date or city pair.")
+		os.Exit(0)
+	}
+
+	cheapest := flights[0]
+	fmt.Printf("Cheapest flight: %s -> %s\n", origin, dest)
+	fmt.Printf("%s %s\n", cheapest.Airline, cheapest.FlightNumber)
+	fmt.Printf("$%d\n", cheapest.Price)
+	fmt.Printf("Departs %s | Arrives %s\n", cheapest.DepartureTime, cheapest.ArrivalTime)
+	fmt.Printf("Duration: %s\n", cheapest.Duration)
+}

--- a/go/searcher.go
+++ b/go/searcher.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"sort"
+)
+
+// baseURL is the SerpAPI endpoint. Override in tests via the package-level var.
+var baseURL = "https://serpapi.com/search"
+
+// SearchFlights fetches flights from SerpAPI for the given origin, destination, and date.
+// Returns flights sorted by price ascending.
+func SearchFlights(origin, dest, date string) ([]Flight, error) {
+	apiKey := os.Getenv("SERPAPI_KEY")
+	if apiKey == "" {
+		return nil, fmt.Errorf("SERPAPI_KEY environment variable is not set. Get a key at https://serpapi.com")
+	}
+
+	params := url.Values{
+		"engine":        {"google_flights"},
+		"departure_id":  {origin},
+		"arrival_id":    {dest},
+		"outbound_date": {date},
+		"currency":      {"USD"},
+		"hl":            {"en"},
+		"api_key":       {apiKey},
+		"type":          {"2"},
+	}
+	reqURL := baseURL + "?" + params.Encode()
+
+	resp, err := http.Get(reqURL) //nolint:noctx
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("API returned status %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response body: %w", err)
+	}
+
+	return ParseFlights(string(body))
+}
+
+// serpAPIResponse mirrors the relevant parts of a SerpAPI Google Flights response.
+type serpAPIResponse struct {
+	BestFlights  []flightGroup `json:"best_flights"`
+	OtherFlights []flightGroup `json:"other_flights"`
+}
+
+type flightGroup struct {
+	Flights []legData `json:"flights"`
+	Price   int       `json:"price"`
+}
+
+type legData struct {
+	DepartureAirport airportTime `json:"departure_airport"`
+	ArrivalAirport   airportTime `json:"arrival_airport"`
+	Duration         int         `json:"duration"`
+	Airline          string      `json:"airline"`
+	FlightNumber     string      `json:"flight_number"`
+}
+
+type airportTime struct {
+	Time string `json:"time"`
+}
+
+// ParseFlights parses a SerpAPI JSON response and returns flights sorted by price ascending.
+func ParseFlights(jsonText string) ([]Flight, error) {
+	var data serpAPIResponse
+	if err := json.Unmarshal([]byte(jsonText), &data); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON: %w", err)
+	}
+
+	var flights []Flight
+
+	for _, groups := range [][]flightGroup{data.BestFlights, data.OtherFlights} {
+		for _, group := range groups {
+			legs := group.Flights
+			if len(legs) == 0 {
+				continue
+			}
+
+			firstLeg := legs[0]
+			lastLeg := legs[len(legs)-1]
+
+			totalDuration := 0
+			for _, leg := range legs {
+				totalDuration += leg.Duration
+			}
+
+			flights = append(flights, Flight{
+				Airline:       firstLeg.Airline,
+				FlightNumber:  firstLeg.FlightNumber,
+				Price:         group.Price,
+				DepartureTime: firstLeg.DepartureAirport.Time,
+				ArrivalTime:   lastLeg.ArrivalAirport.Time,
+				Duration:      formatDuration(totalDuration),
+			})
+		}
+	}
+
+	sort.Slice(flights, func(i, j int) bool {
+		return flights[i].Price < flights[j].Price
+	})
+
+	return flights, nil
+}
+
+// formatDuration converts total minutes into a human-readable "Xh Ym" string.
+func formatDuration(minutes int) string {
+	return fmt.Sprintf("%dh %dm", minutes/60, minutes%60)
+}

--- a/go/searcher_test.go
+++ b/go/searcher_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+const mockJSON = `{
+    "best_flights": [
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 08:05"},
+                    "arrival_airport":   {"time": "2024-01-15 16:23"},
+                    "duration": 318,
+                    "airline": "United Airlines",
+                    "flight_number": "UA 101"
+                }
+            ],
+            "price": 189
+        }
+    ],
+    "other_flights": [
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 10:30"},
+                    "arrival_airport":   {"time": "2024-01-15 18:45"},
+                    "duration": 315,
+                    "airline": "Delta Air Lines",
+                    "flight_number": "DL 405"
+                }
+            ],
+            "price": 245
+        },
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 06:00"},
+                    "arrival_airport":   {"time": "2024-01-15 14:10"},
+                    "duration": 310,
+                    "airline": "JetBlue",
+                    "flight_number": "B6 816"
+                }
+            ],
+            "price": 159
+        }
+    ]
+}`
+
+func TestParseFlights_ValidJSON(t *testing.T) {
+	flights, err := ParseFlights(mockJSON)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(flights) != 3 {
+		t.Fatalf("expected 3 flights, got %d", len(flights))
+	}
+
+	// Sorted by price ascending: 159, 189, 245
+	if flights[0].Price != 159 {
+		t.Errorf("flights[0].Price = %d, want 159", flights[0].Price)
+	}
+	if flights[1].Price != 189 {
+		t.Errorf("flights[1].Price = %d, want 189", flights[1].Price)
+	}
+	if flights[2].Price != 245 {
+		t.Errorf("flights[2].Price = %d, want 245", flights[2].Price)
+	}
+
+	// Cheapest is JetBlue B6 816
+	if flights[0].Airline != "JetBlue" {
+		t.Errorf("flights[0].Airline = %q, want %q", flights[0].Airline, "JetBlue")
+	}
+	if flights[0].FlightNumber != "B6 816" {
+		t.Errorf("flights[0].FlightNumber = %q, want %q", flights[0].FlightNumber, "B6 816")
+	}
+	if flights[0].Duration != "5h 10m" {
+		t.Errorf("flights[0].Duration = %q, want %q", flights[0].Duration, "5h 10m")
+	}
+}
+
+func TestParseFlights_EmptyJSON(t *testing.T) {
+	flights, err := ParseFlights(`{}`)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(flights) != 0 {
+		t.Errorf("expected 0 flights, got %d", len(flights))
+	}
+}
+
+func TestParseFlights_InvalidJSON(t *testing.T) {
+	_, err := ParseFlights(`not valid json`)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestSearchFlights_MissingSerpAPIKey(t *testing.T) {
+	old := os.Getenv("SERPAPI_KEY")
+	os.Unsetenv("SERPAPI_KEY")
+	defer os.Setenv("SERPAPI_KEY", old)
+
+	_, err := SearchFlights("SFO", "JFK", "2024-01-15")
+	if err == nil {
+		t.Fatal("expected error for missing SERPAPI_KEY, got nil")
+	}
+
+	msg := err.Error()
+	if msg == "" {
+		t.Error("error message should not be empty")
+	}
+
+	found := false
+	for i := 0; i+len("SERPAPI_KEY") <= len(msg); i++ {
+		if msg[i:i+len("SERPAPI_KEY")] == "SERPAPI_KEY" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected 'SERPAPI_KEY' in error message, got: %q", msg)
+	}
+}
+
+func TestSearchFlights_HTTPTest(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(mockJSON)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	// Override base URL and set a fake API key.
+	origURL := baseURL
+	baseURL = srv.URL
+	defer func() { baseURL = origURL }()
+
+	os.Setenv("SERPAPI_KEY", "test-key")
+	defer os.Unsetenv("SERPAPI_KEY")
+
+	flights, err := SearchFlights("SFO", "JFK", "2024-01-15")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(flights) != 3 {
+		t.Errorf("expected 3 flights, got %d", len(flights))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #14

Adds a new `go/` directory with a complete, idiomatic Go port of the fare-finder CLI. Mirrors the structure and behaviour of the existing Python implementation — no external dependencies (stdlib only).

## Files added

| File | Contents |
|---|---|
| `go/go.mod` | Module `github.com/lakamsani/fare-finder/go`, go 1.21, stdlib-only |
| `go/flight.go` | `Flight` struct with exported fields |
| `go/airport.go` | 42-city IATA lookup map + exported `LookupAirport` |
| `go/searcher.go` | `SearchFlights`, `ParseFlights`, `formatDuration`; `baseURL` var overridable in tests |
| `go/main.go` | CLI entry point — arg validation, title-case, date, output matching Python exactly |
| `go/airport_test.go` | Known city lookups + unknown city error case |
| `go/searcher_test.go` | Valid/empty/invalid JSON, missing SERPAPI_KEY, `httptest.NewServer` integration |
| `go/README.md` | Usage and setup docs |

## Usage

```bash
cd go
export SERPAPI_KEY=your_key_here
go run . "San Francisco" CA "New York" NY
```

## Tests

```bash
cd go
go test -v ./...
```