### PR TITLE
feat: Rust port of fare-finder

### DIFF
--- a/.github/workflows/rust-test.yml
+++ b/.github/workflows/rust-test.yml
@@ -1,0 +1,36 @@
+name: Rust Tests
+
+on:
+  push:
+    paths:
+      - 'rust/**'
+  pull_request:
+    paths:
+      - 'rust/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            rust/target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('rust/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-
+
+      - name: Build
+        working-directory: rust
+        run: cargo build --verbose
+
+      - name: Test
+        working-directory: rust
+        run: cargo test --verbose

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "fare-finder"
+version = "0.1.0"
+edition = "2021"
+description = "CLI tool to find the cheapest US domestic flight between two cities (Rust port)"
+
+[[bin]]
+name = "fare-finder"
+path = "src/main.rs"
+
+[lib]
+name = "fare_finder"
+path = "src/lib.rs"
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+ureq = "2"
+
+[dev-dependencies]

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,64 @@
+# fare-finder — Rust port
+
+CLI tool to find the cheapest US domestic flight between two cities.
+
+> Implements [issue #17](https://github.com/lakamsani/fare-finder/issues/17) — Rust port.
+
+## Prerequisites
+
+- Rust 1.75+ (via [rustup](https://rustup.rs))
+- A [SerpAPI](https://serpapi.com) key (free tier available)
+
+## Build
+
+```bash
+cd rust
+cargo build --release
+```
+
+## Usage
+
+```
+./target/release/fare-finder <city1> <state1> <city2> <state2>
+```
+
+**Example:**
+
+```bash
+export SERPAPI_KEY=your_key_here
+./target/release/fare-finder "San Francisco" CA "New York" NY
+```
+
+**Output:**
+```
+Searching for flights SFO -> JFK on 2024-01-16...
+
+Cheapest flight: SFO -> JFK
+United Airlines UA 101
+$189
+Departs 2024-01-16 08:05 | Arrives 2024-01-16 16:23
+Duration: 5h 18m
+```
+
+## Run Tests
+
+```bash
+cd rust
+cargo test
+```
+
+## Project Structure
+
+```
+rust/
+├── Cargo.toml
+├── src/
+│   ├── lib.rs          # Public library surface
+│   ├── main.rs         # CLI entry point
+│   ├── flight.rs       # Flight struct
+│   ├── airport.rs      # IATA airport lookup
+│   └── searcher.rs     # SerpAPI client + JSON parsing
+└── tests/
+    ├── airport_test.rs
+    └── searcher_test.rs
+```

--- a/rust/src/airport.rs
+++ b/rust/src/airport.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+
+/// Returns a map from "city,state" (lowercase) to IATA airport code.
+fn airports() -> HashMap<&'static str, &'static str> {
+    let mut m = HashMap::new();
+    m.insert("new york,ny",      "JFK");
+    m.insert("los angeles,ca",   "LAX");
+    m.insert("chicago,il",       "ORD");
+    m.insert("houston,tx",       "IAH");
+    m.insert("phoenix,az",       "PHX");
+    m.insert("philadelphia,pa",  "PHL");
+    m.insert("san antonio,tx",   "SAT");
+    m.insert("san diego,ca",     "SAN");
+    m.insert("dallas,tx",        "DFW");
+    m.insert("san jose,ca",      "SJC");
+    m.insert("austin,tx",        "AUS");
+    m.insert("jacksonville,fl",  "JAX");
+    m.insert("san francisco,ca", "SFO");
+    m.insert("columbus,oh",      "CMH");
+    m.insert("charlotte,nc",     "CLT");
+    m.insert("indianapolis,in",  "IND");
+    m.insert("seattle,wa",       "SEA");
+    m.insert("denver,co",        "DEN");
+    m.insert("nashville,tn",     "BNA");
+    m.insert("oklahoma city,ok", "OKC");
+    m.insert("el paso,tx",       "ELP");
+    m.insert("washington,dc",    "DCA");
+    m.insert("las vegas,nv",     "LAS");
+    m.insert("louisville,ky",    "SDF");
+    m.insert("baltimore,md",     "BWI");
+    m.insert("milwaukee,wi",     "MKE");
+    m.insert("albuquerque,nm",   "ABQ");
+    m.insert("tucson,az",        "TUS");
+    m.insert("fresno,ca",        "FAT");
+    m.insert("sacramento,ca",    "SMF");
+    m.insert("kansas city,mo",   "MCI");
+    m.insert("atlanta,ga",       "ATL");
+    m.insert("miami,fl",         "MIA");
+    m.insert("minneapolis,mn",   "MSP");
+    m.insert("portland,or",      "PDX");
+    m.insert("detroit,mi",       "DTW");
+    m.insert("boston,ma",        "BOS");
+    m.insert("memphis,tn",       "MEM");
+    m.insert("new orleans,la",   "MSY");
+    m.insert("cleveland,oh",     "CLE");
+    m.insert("tampa,fl",         "TPA");
+    m.insert("orlando,fl",       "MCO");
+    m
+}
+
+/// Returns the IATA airport code for a given city and state.
+///
+/// # Errors
+/// Returns an error string if no airport is found for the city/state pair.
+pub fn lookup_airport(city: &str, state: &str) -> Result<&'static str, String> {
+    let key = format!("{},{}", city.trim().to_lowercase(), state.trim().to_lowercase());
+    airports()
+        .get(key.as_str())
+        .copied()
+        .ok_or_else(|| format!("no airport found for {}, {}", city, state))
+}

--- a/rust/src/flight.rs
+++ b/rust/src/flight.rs
@@ -1,0 +1,26 @@
+/// Represents a single flight option.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Flight {
+    pub airline: String,
+    pub flight_number: String,
+    pub price: u32,
+    pub departure_time: String,
+    pub arrival_time: String,
+    pub duration: String,
+}
+
+impl std::fmt::Display for Flight {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Flight {{ airline: {:?}, flight_number: {:?}, price: {}, \
+             departure_time: {:?}, arrival_time: {:?}, duration: {:?} }}",
+            self.airline,
+            self.flight_number,
+            self.price,
+            self.departure_time,
+            self.arrival_time,
+            self.duration,
+        )
+    }
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,0 +1,3 @@
+pub mod airport;
+pub mod flight;
+pub mod searcher;

--- a/rust/src/main.rs
+++ b/rust/src/main.rs
@@ -1,0 +1,106 @@
+// fare-finder: CLI tool to find the cheapest US domestic flight between two cities (Rust port).
+//
+// Fixes https://github.com/lakamsani/fare-finder/issues/17
+
+use fare_finder::airport;
+use fare_finder::searcher;
+
+use std::process;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() != 5 {
+        eprintln!("Usage: fare-finder <city1> <state1> <city2> <state2>");
+        eprintln!(r#"Example: fare-finder "San Francisco" CA "New York" NY"#);
+        process::exit(1);
+    }
+
+    let city1 = title_case(args[1].trim());
+    let state1 = args[2].trim().to_uppercase();
+    let city2 = title_case(args[3].trim());
+    let state2 = args[4].trim().to_uppercase();
+
+    let origin = match airport::lookup_airport(&city1, &state1) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    };
+
+    let dest = match airport::lookup_airport(&city2, &state2) {
+        Ok(code) => code,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    };
+
+    let tomorrow = {
+        // chrono not used to keep deps minimal — compute date manually via std
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_secs();
+        let days = now / 86400 + 1; // days since epoch + 1 = tomorrow
+        epoch_days_to_date(days)
+    };
+
+    println!("Searching for flights {} -> {} on {}...\n", origin, dest, tomorrow);
+
+    let flights = match searcher::search_flights(origin, dest, &tomorrow) {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            process::exit(1);
+        }
+    };
+
+    if flights.is_empty() {
+        println!("No flights found for this route and date. Try a different date or city pair.");
+        process::exit(0);
+    }
+
+    let cheapest = &flights[0];
+    println!("Cheapest flight: {} -> {}", origin, dest);
+    println!("{} {}", cheapest.airline, cheapest.flight_number);
+    println!("${}", cheapest.price);
+    println!("Departs {} | Arrives {}", cheapest.departure_time, cheapest.arrival_time);
+    println!("Duration: {}", cheapest.duration);
+}
+
+/// Converts a string so that each word starts with an uppercase letter
+/// and the remaining letters are lowercase.
+fn title_case(s: &str) -> String {
+    s.split_whitespace()
+        .map(|word| {
+            let mut chars = word.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(first) => {
+                    first.to_uppercase().to_string()
+                        + &chars.as_str().to_lowercase()
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// Converts days since Unix epoch to a "YYYY-MM-DD" string without external crates.
+fn epoch_days_to_date(days: u64) -> String {
+    // Algorithm: civil date from days since epoch (1970-01-01)
+    // Reference: http://howardhinnant.github.io/date_algorithms.html
+    let z = days as i64 + 719468;
+    let era = if z >= 0 { z } else { z - 146096 } / 146097;
+    let doe = (z - era * 146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    format!("{:04}-{:02}-{:02}", y, m, d)
+}

--- a/rust/src/searcher.rs
+++ b/rust/src/searcher.rs
@@ -1,0 +1,131 @@
+use serde::Deserialize;
+use std::env;
+
+use crate::flight::Flight;
+
+/// SerpAPI endpoint — overridable via the `SERPAPI_BASE_URL` env var (for tests).
+fn base_url() -> String {
+    env::var("SERPAPI_BASE_URL").unwrap_or_else(|_| "https://serpapi.com/search".to_string())
+}
+
+// ---------- JSON shapes ----------
+
+#[derive(Deserialize)]
+struct SerpResponse {
+    #[serde(default)]
+    best_flights: Vec<FlightGroup>,
+    #[serde(default)]
+    other_flights: Vec<FlightGroup>,
+}
+
+#[derive(Deserialize)]
+struct FlightGroup {
+    #[serde(default)]
+    flights: Vec<FlightLeg>,
+    #[serde(default)]
+    price: u32,
+}
+
+#[derive(Deserialize)]
+struct FlightLeg {
+    #[serde(default)]
+    airline: String,
+    #[serde(default)]
+    flight_number: String,
+    #[serde(default)]
+    duration: u32,
+    #[serde(default)]
+    departure_airport: TimeNode,
+    #[serde(default)]
+    arrival_airport: TimeNode,
+}
+
+#[derive(Deserialize, Default)]
+struct TimeNode {
+    #[serde(default)]
+    time: String,
+}
+
+// ---------- Public API ----------
+
+/// Fetches flights from SerpAPI for the given origin, destination, and date.
+///
+/// * `origin` / `dest` — 3-letter IATA codes  
+/// * `date` — `YYYY-MM-DD`
+///
+/// Returns flights sorted by price ascending.
+///
+/// # Errors
+/// Returns an error string if the API key is missing, the HTTP request fails,
+/// or the response is not valid JSON.
+pub fn search_flights(origin: &str, dest: &str, date: &str) -> Result<Vec<Flight>, String> {
+    let api_key = env::var("SERPAPI_KEY")
+        .unwrap_or_default();
+
+    if api_key.is_empty() {
+        return Err(
+            "SERPAPI_KEY environment variable is not set. Get a key at https://serpapi.com"
+                .to_string(),
+        );
+    }
+
+    let url = format!(
+        "{}?engine=google_flights&departure_id={}&arrival_id={}&outbound_date={}\
+         &currency=USD&hl=en&api_key={}&type=2",
+        base_url(),
+        origin,
+        dest,
+        date,
+        api_key,
+    );
+
+    let response = ureq::get(&url)
+        .call()
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    if response.status() != 200 {
+        return Err(format!("API returned status {}", response.status()));
+    }
+
+    let body = response
+        .into_string()
+        .map_err(|e| format!("failed to read response body: {}", e))?;
+
+    parse_flights(&body)
+}
+
+/// Parses a SerpAPI JSON response and returns flights sorted by price ascending.
+///
+/// # Errors
+/// Returns an error string if the JSON is malformed.
+pub fn parse_flights(json: &str) -> Result<Vec<Flight>, String> {
+    let data: SerpResponse =
+        serde_json::from_str(json).map_err(|e| format!("failed to parse JSON: {}", e))?;
+
+    let mut flights = Vec::new();
+
+    for group in data.best_flights.iter().chain(data.other_flights.iter()) {
+        if group.flights.is_empty() {
+            continue;
+        }
+        let first = &group.flights[0];
+        let last = &group.flights[group.flights.len() - 1];
+        let total_duration: u32 = group.flights.iter().map(|l| l.duration).sum();
+
+        flights.push(Flight {
+            airline: first.airline.clone(),
+            flight_number: first.flight_number.clone(),
+            price: group.price,
+            departure_time: first.departure_airport.time.clone(),
+            arrival_time: last.arrival_airport.time.clone(),
+            duration: format_duration(total_duration),
+        });
+    }
+
+    flights.sort_by_key(|f| f.price);
+    Ok(flights)
+}
+
+fn format_duration(minutes: u32) -> String {
+    format!("{}h {}m", minutes / 60, minutes % 60)
+}

--- a/rust/tests/airport_test.rs
+++ b/rust/tests/airport_test.rs
@@ -1,0 +1,31 @@
+use fare_finder::airport::lookup_airport;
+
+#[test]
+fn test_known_airports() {
+    let cases = vec![
+        ("San Francisco", "CA", "SFO"),
+        ("New York",      "NY", "JFK"),
+        ("Chicago",       "IL", "ORD"),
+        ("Atlanta",       "GA", "ATL"),
+        ("Denver",        "CO", "DEN"),
+        ("Seattle",       "WA", "SEA"),
+        ("Miami",         "FL", "MIA"),
+        ("Las Vegas",     "NV", "LAS"),
+        ("Boston",        "MA", "BOS"),
+        ("Dallas",        "TX", "DFW"),
+    ];
+
+    for (city, state, want) in cases {
+        let got = lookup_airport(city, state)
+            .unwrap_or_else(|e| panic!("lookup_airport({:?}, {:?}) failed: {}", city, state, e));
+        assert_eq!(got, want, "lookup_airport({:?}, {:?})", city, state);
+    }
+}
+
+#[test]
+fn test_unknown_city_returns_error() {
+    let result = lookup_airport("Nonexistent City", "XX");
+    assert!(result.is_err(), "expected Err for unknown city, got Ok");
+    let msg = result.unwrap_err();
+    assert!(!msg.is_empty(), "error message should not be empty");
+}

--- a/rust/tests/searcher_test.rs
+++ b/rust/tests/searcher_test.rs
@@ -1,0 +1,92 @@
+use fare_finder::searcher::parse_flights;
+
+const MOCK_JSON: &str = r#"{
+    "best_flights": [
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 08:05"},
+                    "arrival_airport":   {"time": "2024-01-15 16:23"},
+                    "duration": 318,
+                    "airline": "United Airlines",
+                    "flight_number": "UA 101"
+                }
+            ],
+            "price": 189
+        }
+    ],
+    "other_flights": [
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 10:30"},
+                    "arrival_airport":   {"time": "2024-01-15 18:45"},
+                    "duration": 315,
+                    "airline": "Delta Air Lines",
+                    "flight_number": "DL 405"
+                }
+            ],
+            "price": 245
+        },
+        {
+            "flights": [
+                {
+                    "departure_airport": {"time": "2024-01-15 06:00"},
+                    "arrival_airport":   {"time": "2024-01-15 14:10"},
+                    "duration": 310,
+                    "airline": "JetBlue",
+                    "flight_number": "B6 816"
+                }
+            ],
+            "price": 159
+        }
+    ]
+}"#;
+
+#[test]
+fn test_parse_flights_sorted_by_price() {
+    let flights = parse_flights(MOCK_JSON).expect("parse_flights failed");
+
+    assert_eq!(flights.len(), 3, "expected 3 flights, got {}", flights.len());
+
+    // Sorted by price ascending: 159, 189, 245
+    assert_eq!(flights[0].price, 159);
+    assert_eq!(flights[1].price, 189);
+    assert_eq!(flights[2].price, 245);
+
+    // Cheapest is JetBlue B6 816
+    assert_eq!(flights[0].airline, "JetBlue");
+    assert_eq!(flights[0].flight_number, "B6 816");
+    assert_eq!(flights[0].duration, "5h 10m");
+}
+
+#[test]
+fn test_parse_flights_empty_json() {
+    let flights = parse_flights("{}").expect("parse_flights failed on empty object");
+    assert!(flights.is_empty(), "expected empty list for empty JSON");
+}
+
+#[test]
+fn test_parse_flights_invalid_json() {
+    let result = parse_flights("not json at all");
+    assert!(result.is_err(), "expected error for invalid JSON");
+    let msg = result.unwrap_err();
+    assert!(msg.contains("failed to parse JSON"), "unexpected error: {}", msg);
+}
+
+#[test]
+fn test_missing_serpapi_key_returns_error() {
+    // Ensure the env var is unset for this test
+    std::env::remove_var("SERPAPI_KEY");
+    // Also clear SERPAPI_BASE_URL so we don't hit a real server
+    std::env::remove_var("SERPAPI_BASE_URL");
+
+    let result = fare_finder::searcher::search_flights("SFO", "JFK", "2024-01-15");
+    assert!(result.is_err(), "expected error when SERPAPI_KEY is missing");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("SERPAPI_KEY"),
+        "expected 'SERPAPI_KEY' in error message, got: {:?}",
+        msg
+    );
+}


### PR DESCRIPTION
## Summary

Adds a complete Rust port of the fare-finder CLI, matching the structure of the existing Java, Python, TypeScript, and Go implementations.

## Changes

- `rust/src/flight.rs` — `Flight` struct with `Display` impl
- `rust/src/airport.rs` — `lookup_airport` with full 41-city IATA map
- `rust/src/searcher.rs` — `search_flights` (ureq HTTP client) + `parse_flights` (serde_json); `SERPAPI_BASE_URL` env override for tests
- `rust/src/main.rs` — CLI entry point with same UX as other ports
- `rust/src/lib.rs` — public library surface for integration tests
- `rust/tests/airport_test.rs` — parametrized airport lookup tests + unknown-city error
- `rust/tests/searcher_test.rs` — parse sort order, empty JSON, invalid JSON, missing key error
- `.github/workflows/rust-test.yml` — CI: build + test on stable Rust

## Testing

Tests cover:
- All 10 known airports via parametrized cases
- Unknown city returns `Err`
- `parse_flights` produces 3 flights sorted by price (159, 189, 245)
- Cheapest flight is JetBlue B6 816, duration 5h 10m
- Empty JSON object returns empty list
- Malformed JSON returns a descriptive error
- Missing `SERPAPI_KEY` returns a descriptive error mentioning `SERPAPI_KEY`

CI runs `cargo build` + `cargo test` on stable Rust on every push/PR touching `rust/**`.

Fixes #17