### PR TITLE
chore: update README for Python-only implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,41 +2,19 @@
 
 A command-line tool for finding the cheapest one-way flights between US cities using the SerpAPI Google Flights engine.
 
-## Go
-
-### Build
-
-```
-go build -o fare-finder .
-```
-
-### Run
-
-```
-SERPAPI_KEY=<key> ./fare-finder "San Francisco" CA "New York" NY
-```
-
-### Test
-
-```
-go test ./...
-```
-
-## Python
-
-### Install
+## Install
 
 ```
 pip install .
 ```
 
-### Run
+## Run
 
 ```
 SERPAPI_KEY=<key> python -m fare_finder "San Francisco" CA "New York" NY
 ```
 
-### Test
+## Test
 
 ```
 pip install pytest


### PR DESCRIPTION
Removes the Go instructions from the README. Only Python install/run/test instructions remain.